### PR TITLE
Fix config validation

### DIFF
--- a/repo/packages/J/jenkins/0/config.json
+++ b/repo/packages/J/jenkins/0/config.json
@@ -1,5 +1,11 @@
 {
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
-  "properties": {}
+  "properties": {
+    "port": {
+      "type": "integer",
+      "default": 8080
+    }
+  },
+  "additionalProperties": false
 }

--- a/repo/packages/J/jenkins/0/marathon.json
+++ b/repo/packages/J/jenkins/0/marathon.json
@@ -8,7 +8,7 @@
    "uris": [
       "https://s3.amazonaws.com/downloads.mesosphere.io/jenkins/0.7.0/jenkins-on-mesos.tgz"
    ],
-   "cmd": "cd jenkins-on-mesos && export JENKINS_HOME=$(pwd) && export JENKINS_URL=http://$MESOS_HOSTNAME:$PORT0 && java $JAVA_OPTS -jar jenkins.war --httpPort=$PORT0",
+   "cmd": "cd jenkins-on-mesos && export JENKINS_HOME=$(pwd) && export JENKINS_URL=http://$MESOS_HOSTNAME:{{port}} && java $JAVA_OPTS -jar jenkins.war --httpPort={{port}}",
    "healthChecks": [
     {
       "protocol": "HTTP",

--- a/repo/packages/J/jenkins/0/marathon.json
+++ b/repo/packages/J/jenkins/0/marathon.json
@@ -6,9 +6,9 @@
     "JAVA_OPTS": "-Xmx1024m"
    },
    "uris": [
-      "https://s3.amazonaws.com/downloads.mesosphere.io/jenkins/0.7.0/jenkins-on-mesos.tgz"
+      "https://s3.amazonaws.com/downloads.mesosphere.io/jenkins/0.6.0/jenkins-on-mesos.tgz"
    ],
-   "cmd": "cd jenkins-on-mesos && export JENKINS_HOME=$(pwd) && export JENKINS_URL=http://$MESOS_HOSTNAME:{{port}} && java $JAVA_OPTS -jar jenkins.war --httpPort={{port}}",
+   "cmd": "cd jenkins-on-mesos && export JENKINS_HOME=$(pwd) && export JENKINS_URL=http://$MESOS_HOSTNAME:$PORT0 && java $JAVA_OPTS -jar jenkins.war --httpPort=$PORT0",
    "healthChecks": [
     {
       "protocol": "HTTP",

--- a/repo/packages/Z/zeppelin/0/config.json
+++ b/repo/packages/Z/zeppelin/0/config.json
@@ -1,5 +1,12 @@
 {
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
-  "properties": {}
+  "properties": {
+  	"properties": {
+    "port": {
+      "type": "integer",
+      "default": 8080
+    }
+  },
+  "additionalProperties": false
 }

--- a/repo/packages/Z/zeppelin/0/config.json
+++ b/repo/packages/Z/zeppelin/0/config.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "properties": {
-  	"properties": {
     "port": {
       "type": "integer",
       "default": 8080

--- a/repo/packages/Z/zeppelin/0/marathon.json
+++ b/repo/packages/Z/zeppelin/0/marathon.json
@@ -15,7 +15,7 @@
         "timeoutSeconds": 15,
         "maxConsecutiveFailures": 3
     }],
-    "cmd": "sed \"s#<value>8080</value>#<value>$PORT0</value>#\" < conf/zeppelin-site.xml.template > conf/zeppelin-site.xml && sed -i \"s#<value>-1</value>#<value>$PORT1</value>#\" conf/zeppelin-site.xml && bin/zeppelin.sh start",
+    "cmd": "sed \"s#<value>8080</value>#<value>{{port}}</value>#\" < conf/zeppelin-site.xml.template > conf/zeppelin-site.xml && sed -i \"s#<value>-1</value>#<value>$PORT1</value>#\" conf/zeppelin-site.xml && bin/zeppelin.sh start",
     "ports": [0, 0],
     "cpus": 1,
     "mem": 1024.0

--- a/repo/packages/Z/zeppelin/0/marathon.json
+++ b/repo/packages/Z/zeppelin/0/marathon.json
@@ -15,7 +15,7 @@
         "timeoutSeconds": 15,
         "maxConsecutiveFailures": 3
     }],
-    "cmd": "sed \"s#<value>8080</value>#<value>{{port}}</value>#\" < conf/zeppelin-site.xml.template > conf/zeppelin-site.xml && sed -i \"s#<value>-1</value>#<value>$PORT1</value>#\" conf/zeppelin-site.xml && bin/zeppelin.sh start",
+    "cmd": "sed \"s#<value>8080</value>#<value>$PORT0</value>#\" < conf/zeppelin-site.xml.template > conf/zeppelin-site.xml && sed -i \"s#<value>-1</value>#<value>$PORT1</value>#\" conf/zeppelin-site.xml && bin/zeppelin.sh start",
     "ports": [0, 0],
     "cpus": 1,
     "mem": 1024.0


### PR DESCRIPTION
In the current version of mesosphere, config.json requires a port property.
Set the property in config.json, and update marathon.json to use this property.
This means that jenkins and zeppelin should now install.
