### PR TITLE
Add kubernetes.resource-roles config

### DIFF
--- a/repo/packages/K/kubernetes/1/config.json
+++ b/repo/packages/K/kubernetes/1/config.json
@@ -85,7 +85,6 @@
           "default": ["slave_public"],
           "description": "List of acceptable Mesos resource roles to consider when scheduling the Kubernetes Marathon container.",
           "items": {
-            "pattern": "^[\\s]+",
             "type": "string"
           },
           "type": "array"

--- a/repo/packages/K/kubernetes/1/config.json
+++ b/repo/packages/K/kubernetes/1/config.json
@@ -176,7 +176,7 @@
           "default": [],
           "description": "List of URIs that will be download and made available in the current working directory of the scheduler.",
           "items": {
-            "pattern": "^[\\s]+",
+            "pattern": "^[^\\s]+$",
             "type": "string"
           },
           "type": "array"

--- a/repo/packages/K/kubernetes/1/config.json
+++ b/repo/packages/K/kubernetes/1/config.json
@@ -85,7 +85,7 @@
           "default": ["slave_public"],
           "description": "List of acceptable Mesos resource roles to consider when scheduling the Kubernetes Marathon container.",
           "items": {
-            "pattern": "^[\\S]+$",
+            "pattern": "^[^\\s]+$",
             "type": "string"
           },
           "type": "array"

--- a/repo/packages/K/kubernetes/1/config.json
+++ b/repo/packages/K/kubernetes/1/config.json
@@ -81,6 +81,15 @@
           "minimum": 0,
           "type": "integer"
         },
+        "resource-roles": {
+          "default": ["slave_public"],
+          "description": "List of acceptable Mesos resource roles to consider when scheduling the Kubernetes Marathon container.",
+          "items": {
+            "pattern": "^[\\s]+",
+            "type": "string"
+          },
+          "type": "array"
+        },
         "apiserver-port": {
           "default": 25500,
           "description": "Read/write host port that the Kubernetes apiserver listens on.",

--- a/repo/packages/K/kubernetes/1/config.json
+++ b/repo/packages/K/kubernetes/1/config.json
@@ -146,13 +146,13 @@
         },
         "default-container-cpu-limit": {
           "default": 0.25,
-          "description": "CPU shared to allocate to a containter in a pod which is not CPU limited.",
+          "description": "CPU shared to allocate to a container in a pod which is not CPU limited.",
           "minimum": 0.01,
           "type": "number"
         },
         "default-container-mem-limit": {
           "default": 64.0,
-          "description": "Memory (MB) to allocate to a containter in a pod which is not memory limited.",
+          "description": "Memory (MB) to allocate to a container in a pod which is not memory limited.",
           "minimum": 32.0,
           "type": "number"
         },
@@ -200,7 +200,7 @@
       "type": "object"
     },
     "mesos": {
-      "depscription": "Mesos specific configuration properties",
+      "description": "Mesos specific configuration properties",
       "properties": {
         "master": {
           "default": "zk://master.mesos:2181/mesos",

--- a/repo/packages/K/kubernetes/1/config.json
+++ b/repo/packages/K/kubernetes/1/config.json
@@ -85,6 +85,7 @@
           "default": ["slave_public"],
           "description": "List of acceptable Mesos resource roles to consider when scheduling the Kubernetes Marathon container.",
           "items": {
+            "pattern": "^[\\S]+$",
             "type": "string"
           },
           "type": "array"

--- a/repo/packages/K/kubernetes/1/marathon.json
+++ b/repo/packages/K/kubernetes/1/marathon.json
@@ -2,6 +2,7 @@
   "id": "{{kubernetes.framework-name}}",
   "cpus": {{kubernetes.cpus}},
   "mem": {{kubernetes.mem}},
+  "acceptedResourceRoles": {{kubernetes.resource-roles}},
   "container": {
     "type": "DOCKER",
     "docker": {

--- a/repo/packages/K/kubernetes/1/marathon.json
+++ b/repo/packages/K/kubernetes/1/marathon.json
@@ -2,7 +2,7 @@
   "id": "{{kubernetes.framework-name}}",
   "cpus": {{kubernetes.cpus}},
   "mem": {{kubernetes.mem}},
-  "acceptedResourceRoles": {{kubernetes.resource-roles}},
+  "acceptedResourceRoles": {{{kubernetes.resource-roles}}},
   "container": {
     "type": "DOCKER",
     "docker": {


### PR DESCRIPTION
...that maps to Marathon acceptedResourceRoles
- Default to slave_public

This allows targeting the kube-apiserver directly with the public slave IP, which enables SPDY support, which is required for `kubectl exec` and `kubectl logs`. This is basically required for debugging without sshing into the machines.
