### PR TITLE
Add OpenVPN

### DIFF
--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -89,6 +89,19 @@
       }
     },
     {
+      "currentVersion":"0.0.0-0.1",
+      "description":"Your private path to access network resources and services securely",
+      "framework":true,
+      "name":"openvpn",
+      "tags":[
+        "vpn",
+        "remote-access"
+      ],
+      "versions":{
+        "0.0.0-0.1":"0"
+      }
+    },
+    {
       "currentVersion":"0.0.1",
       "description":"Spark Notebook package for DCOS",
       "framework":true,

--- a/repo/packages/O/openvpn/0/config.json
+++ b/repo/packages/O/openvpn/0/config.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "openvpn": {
+      "type": "object",
+      "properties": {
+        "framework-name": {
+            "default": "openvpn",
+            "description": "openvpn framework name",
+            "type": "string"
+        },
+        "cpus": {
+            "default": 0.01,
+            "description": "CPU shares to allocate to each openvpn instance.",
+            "minimum": 0.01,
+            "type": "number"
+        },
+        "mem": {
+            "default": 128.0,
+            "description": "Memory (MB) to allocate to each openvpn task.",
+            "minimum": 64.0,
+            "type": "number"
+        },
+        "instances": {
+            "default": 1,
+            "description": "Number of openvpn instances to run.",
+            "minimum": 1,
+            "type": "integer"
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/repo/packages/O/openvpn/0/marathon.json
+++ b/repo/packages/O/openvpn/0/marathon.json
@@ -1,0 +1,21 @@
+{
+  "id": "{{openvpn.framework-name}}",
+  "cpus": {{openvpn.cpus}},
+  "mem": {{openvpn.mem}},
+  "instances": {{openvpn.instances}},
+  "cmd": "/dcos/bin/run.bash scheduler",
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "mesosphere/dcos-openvpn",
+      "forcePullImage": true,
+      "network": "HOST"
+    }
+  },
+  "ports": [],
+  "env": {
+    "MESOS_CONFIG": "zk://master.mesos:2181/mesos",
+    "IMAGE": "mesosphere/dcos-openvpn",
+    "FRAMEWORK_NAME": "{{openvpn.framework-name}}"
+  }
+}

--- a/repo/packages/O/openvpn/0/package.json
+++ b/repo/packages/O/openvpn/0/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "openvpn",
+  "version": "0.0.0-0.1",
+  "scm": "https://github.com/mesosphere/dcos-openvpn",
+  "description": "Your private path to access network resources and services securely",
+  "maintainer": "support@mesosphere.io",
+  "framework": true,
+  "images": {
+    "icon-small": "https://downloads.mesosphere.io/openvpn/artifacts/images/openvpn-48x48.png",
+    "icon-medium": "https://downloads.mesosphere.io/openvpn/artifacts/images/openvpn-96x96.png",
+    "icon-large": "https://downloads.mesosphere.io/openvpn/artifacts/images/openvpn-256x256.png"
+  },
+  "tags": ["vpn", "remote-access"],
+  "preInstallNotes": "We recommend a minimum of 0.01 CPUs and 64 MB of RAM available for the Marathon Service.",
+  "postInstallNotes": "OpenVPN DCOS Service has been successfully installed!\nSee https://github.com/mesosphere/dcos-openvpn on how to create users.",
+  "postUninstallNotes": "OpenVPN DCOS Service has been uninstalled and will no longer run.\nSee https://github.com/mesosphere/dcos-openvpn on how to remove persisted state.",
+  "licenses": [
+    {
+      "name": "GNU General Public License version 2",
+      "url": "https://github.com/OpenVPN/openvpn/blob/master/COPYING"
+    },
+    {
+      "name": "The MIT License (MIT)",
+      "url": "https://github.com/kylemanna/docker-openvpn/blob/master/LICENSE"
+    }
+  ]
+}


### PR DESCRIPTION
This adds @pyronicide's dcos-openvpn. It's in a early stage but we're using it for our new cluster and I'll work on stabilizing it further. The framework name registration depends on https://github.com/mesosphere/dcos-openvpn/pull/9
