### PR TITLE
Add marathon-lb

### DIFF
--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -118,6 +118,22 @@
       }
     },
     {
+      "currentVersion":"0.0.0-0.1",
+      "description":"HAProxy configured from marathon state",
+      "framework":false,
+      "name":"marathon-lb",
+      "tags":[
+        "loadbalancer",
+        "service-discovery",
+        "reverse-proxy",
+        "proxy",
+        "haproxy"
+      ],
+      "versions":{
+        "0.0.0-0.1":"0"
+      }
+    },
+    {
       "currentVersion":"0.1.1",
       "description":"A distributed NoSQL key-value data store that offers high availability, fault tolerance, operational simplicity, and scalability.",
       "framework":true,

--- a/repo/packages/M/marathon-lb/0/config.json
+++ b/repo/packages/M/marathon-lb/0/config.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "marathon-lb": {
+      "type": "object",
+      "properties": {
+        "framework-name": {
+          "default": "marathon-lb",
+          "description": "Framework Name",
+          "type": "string"
+        },
+        "cpus": {
+          "default": 0.5,
+          "description": "CPU shares to allocate to each marathon-lb instance.",
+          "minimum": 0.5,
+          "type": "number"
+        },
+        "mem": {
+          "default": 256.0,
+          "description": "Memory (MB) to allocate to each marathon-lb task.",
+          "minimum": 128.0,
+          "type": "number"
+        },
+        "instances": {
+          "default": 2,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "ssl-cert": {
+          "description": "TLS Cert and private key for HTTPS.",
+          "type": "string"
+        },
+        "role": {
+          "default": "slave",
+          "description": "Deploy marathon-lb only on nodes with this role.",
+          "type": "string"
+        }
+
+      }
+    }
+  }
+}

--- a/repo/packages/M/marathon-lb/0/marathon.json
+++ b/repo/packages/M/marathon-lb/0/marathon.json
@@ -1,0 +1,38 @@
+{
+  "id": "{{marathon-lb.framework-name}}",
+  "instances": {{marathon-lb.instances}},
+  "cpus": {{marathon-lb.cpus}},
+  "mem": {{marathon-lb.mem}},
+  "maintainer": "support@mesosphere.io",
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "mesosphere/marathon-lb",
+      "forcePullImage": true,
+      "network": "HOST"
+    }
+  },
+  "acceptedResourceRoles": [
+    "{{marathon-lb.role}}"
+  ],
+  "constraints": [
+    ["hostname", "UNIQUE"]
+  ],
+  "healthChecks": [
+    {
+      "path": "/_haproxy_health_check",
+      "portIndex": 0,
+      "protocol": "HTTP",
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "ports": [ 80, 443 ],
+  "env": {
+    "FRAMEWORK_NAME": "{{marathon-lb.framework-name}}",
+    "HAPROXY_SSL_CERT": "{{marathon-lb.ssl-cert}}"
+  }
+}

--- a/repo/packages/M/marathon-lb/0/package.json
+++ b/repo/packages/M/marathon-lb/0/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "marathon-lb",
+  "version": "0.0.0-0.1",
+  "scm": "https://github.com/mesosphere/marathon-lb",
+  "description": "HAProxy configured from marathon state",
+  "maintainer": "support@mesosphere.io",
+  "images": {
+    "icon-small": "https://downloads.mesosphere.io/marathon/assets/icon-service-marathon-small.png",
+    "icon-medium": "https://downloads.mesosphere.io/marathon/assets/icon-service-marathon-medium.png",
+    "icon-large": "https://downloads.mesosphere.io/marathon/assets/icon-service-marathon-large.png"
+  },
+  "tags": ["loadbalancer", "service-discovery", "reverse-proxy", "proxy", "haproxy"],
+  "preInstallNotes": "We recommend a minimum of 0.5 CPUs and 256 MB of RAM available for the Marathon Service.",
+  "postInstallNotes": "Mesosphere-LB DCOS Service has been successfully installed!\nSee https://github.com/mesosphere/marathon-lb for documentation.",
+  "postUninstallNotes": "Mesosphere-LB DCOS Service has been uninstalled and will no longer run.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/mesosphere/marathon/blob/master/LICENSE"
+    },
+    {
+      "name": "GNU General Public License version 2",
+      "url": "http://www.haproxy.org/download/1.6/doc/LICENSE"
+    }
+  ]
+}


### PR DESCRIPTION
This deploys https://github.com/mesosphere/marathon-lb which is basically a dockerized servicerouter.py with some changes to be able to deploy it as a universe package.

Still want to do some more tests before merging but would be happy for early feedback already.
