### PR TITLE
Kubernetes version bump to v1.0.6-v0.6.6

### DIFF
--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -101,8 +101,8 @@
       }
     },
     {
-      "currentVersion":"v1.0.6-v0.6.5-alpha",
-      "description":"Manage a cluster of Linux containers as a single system to accelerate Dev and simplify Ops.",
+      "currentVersion":"v1.0.6-v0.6.6-alpha",
+      "description":"Kubernetes is an open source system for managing containerized applications across multiple hosts, providing basic mechanisms for deployment, maintenance, and scaling of applications.",
       "framework":true,
       "name":"kubernetes",
       "tags":[
@@ -115,7 +115,7 @@
       "versions":{
         "k8s-0.14.2-k8sm-0.5-dcos-20150603T1136520000":"0",
         "v1.0.5-v0.6.4-alpha":"1",
-        "v1.0.6-v0.6.5-alpha":"2"
+        "v1.0.6-v0.6.6-alpha":"2"
       }
     },
     {

--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -101,7 +101,7 @@
       }
     },
     {
-      "currentVersion":"v1.0.5-v0.6.4-alpha",
+      "currentVersion":"v1.0.6-v0.6.5-alpha",
       "description":"Manage a cluster of Linux containers as a single system to accelerate Dev and simplify Ops.",
       "framework":true,
       "name":"kubernetes",
@@ -114,7 +114,8 @@
       ],
       "versions":{
         "k8s-0.14.2-k8sm-0.5-dcos-20150603T1136520000":"0",
-        "v1.0.5-v0.6.4-alpha":"1"
+        "v1.0.5-v0.6.4-alpha":"1",
+        "v1.0.6-v0.6.5-alpha":"2"
       }
     },
     {

--- a/repo/packages/K/kubernetes/2/config.json
+++ b/repo/packages/K/kubernetes/2/config.json
@@ -190,6 +190,27 @@
       ],
       "type": "object"
     },
+    "marathon": {
+      "description": "Marathon specific configuration properties",
+      "properties": {
+        "labels": {
+          "default": {},
+          "description": "Set of labels to be applied to the Kubernetes Marathon application instance.",
+          "type": "object"
+        },
+        "resource-roles": {
+          "default": ["*"],
+          "description": "List of acceptable Mesos resource roles to consider when scheduling the Kubernetes Marathon container. Set to ['slave_public'] to force running Kubernetes on a public slave.",
+          "items": {
+            "pattern": "^[^\\s]+$",
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": ["labels","resource-roles"],
+      "type": "object"
+    },
     "mesos": {
       "description": "Mesos specific configuration properties",
       "properties": {
@@ -205,6 +226,7 @@
   },
   "required": [
     "kubernetes",
+    "marathon",
     "mesos"
   ],
   "type": "object"

--- a/repo/packages/K/kubernetes/2/config.json
+++ b/repo/packages/K/kubernetes/2/config.json
@@ -167,7 +167,7 @@
           "default": [],
           "description": "List of URIs that will be download and made available in the current working directory of the scheduler.",
           "items": {
-            "pattern": "^[\\s]+",
+            "pattern": "^[^\\s]+",
             "type": "string"
           },
           "type": "array"

--- a/repo/packages/K/kubernetes/2/config.json
+++ b/repo/packages/K/kubernetes/2/config.json
@@ -4,7 +4,7 @@
       "description": "Kubernetes specific configuration properties",
       "properties": {
         "docker-image": {
-          "default": "mesosphere/kubernetes:v1.0.6-v0.6.5-alpha",
+          "default": "mesosphere/kubernetes:v1.0.6-v0.6.6-alpha",
           "description": "Docker image used to launch the Kubernetes framework on DCOS.",
           "type": "string"
         },

--- a/repo/packages/K/kubernetes/2/config.json
+++ b/repo/packages/K/kubernetes/2/config.json
@@ -137,13 +137,13 @@
         },
         "default-container-cpu-limit": {
           "default": 0.25,
-          "description": "CPU shared to allocate to a containter in a pod which is not CPU limited.",
+          "description": "CPU shared to allocate to a container in a pod which is not CPU limited.",
           "minimum": 0.01,
           "type": "number"
         },
         "default-container-mem-limit": {
           "default": 64.0,
-          "description": "Memory (MB) to allocate to a containter in a pod which is not memory limited.",
+          "description": "Memory (MB) to allocate to a container in a pod which is not memory limited.",
           "minimum": 32.0,
           "type": "number"
         },
@@ -191,7 +191,7 @@
       "type": "object"
     },
     "mesos": {
-      "depscription": "Mesos specific configuration properties",
+      "description": "Mesos specific configuration properties",
       "properties": {
         "master": {
           "default": "zk://master.mesos:2181/mesos",

--- a/repo/packages/K/kubernetes/2/config.json
+++ b/repo/packages/K/kubernetes/2/config.json
@@ -19,6 +19,12 @@
           "description": "Set to true to enable Kubernetes local DNS services, allows pods to locate services by name.",
           "type": "boolean"
         },
+        "etcd-mesos-framework-name": {
+          "default": "disabled",
+          "description": "Which etcd-mesos framework to rely on. Corresponds to the configured framework-name for an etcd-mesos framework. Set this to disabled to use a local etcd instance in the scheduler container.",
+          "type": "string",
+          "pattern": "^/?(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$"
+        },
         "framework-name": {
           "default": "kubernetes",
           "description": "The framework name to register with Mesos.",
@@ -60,15 +66,6 @@
           "type": "string",
           "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
         },
-        "enable-etcd-server": {
-          "default": true,
-          "description": "Set to false to disable the pre-packaged etcd server component. Do this if you already have an etcd cluster set up that you want to use as the backing store for Kubernetes. Also see the docs for etcd-server-list.",
-          "type": "boolean"
-        },
-        "etcd-server-list": {
-          "description": "Comma-delimited list of URLs that reference etcd-server endpoints. For example, http://myserver:2001,http://anotherserver:2001. Specify this option if you have disabled the built-in etcd-server via disable-etcd-server.",
-          "type": "string"
-        },
         "cpus": {
           "default": 1.0,
           "description": "CPU shares to allocate to each instance.",
@@ -76,7 +73,7 @@
           "type": "number"
         },
         "failover-timeout": {
-          "default": 120,
+          "default": 604800,
           "description": "The failover_timeout for Mesos in seconds. If a new Kubernetes scheduler instance has not re-registered with Mesos this long after a failover, Mesos will shut down all running pods. Requires checkpointing to be enabled.",
           "minimum": 0,
           "type": "integer"
@@ -179,6 +176,7 @@
         }
       },
       "required": [
+        "etcd-mesos-framework-name",
         "framework-name",
         "cpus",
         "dns-suffix",

--- a/repo/packages/K/kubernetes/2/config.json
+++ b/repo/packages/K/kubernetes/2/config.json
@@ -1,0 +1,211 @@
+{
+  "properties": {
+    "kubernetes": {
+      "description": "Kubernetes specific configuration properties",
+      "properties": {
+        "docker-image": {
+          "default": "mesosphere/kubernetes:v1.0.6-v0.6.5-alpha",
+          "description": "Docker image used to launch the Kubernetes framework on DCOS.",
+          "type": "string"
+        },
+        "dns-suffix": {
+          "default": ".marathon.mesos",
+          "description": "This value is appended to the framework-name value to form the canonical DNS name for the Kubernetes components.",
+          "type": "string",
+          "pattern": "^(?:\\.[a-z][a-z0-9]*?(?:-[a-z0-9]+)*)+$"
+        },
+        "enable-dns": {
+          "default": true,
+          "description": "Set to true to enable Kubernetes local DNS services, allows pods to locate services by name.",
+          "type": "boolean"
+        },
+        "framework-name": {
+          "default": "kubernetes",
+          "description": "The framework name to register with Mesos.",
+          "type": "string",
+          "pattern": "^/?(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$"
+        },
+        "kube-dns-domain": {
+          "default": "cluster.local",
+          "description": "Domain used by pods for Kubernetes service lookup.",
+          "type": "string",
+          "pattern": "^(?:[a-z][a-z0-9]*?(?:-[a-z0-9]+)*?\\.)?(?:[a-z][a-z0-9]*?(?:-[a-z0-9]+)*)$"
+        },
+        "kube-dns-service-ip": {
+          "default": "10.10.10.10",
+          "description": "Kubernetes DNS service portal IP address, should fall in service-cluster-ip-range network range.",
+          "type": "string",
+          "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+        },
+        "kube-dns-replicas": {
+          "default": 1,
+          "description": "The number of kube-dns pods that Kubernetes will spin up at deploy time.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "kube-dns-nameservers": {
+          "description": "Comma-delimited list of host:ip entries that point to fallback nameservers. Only used if nameservers cannot be extracted from the slave's /etc/resolv.conf",
+          "type": "string",
+          "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?):(6553[0-5]|655[0-2][0-9]\\d|65[0-4](\\d){2}|6[0-4](\\d){3}|[1-5](\\d){4}|[1-9](\\d){0,3})(?:,(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?):(6553[0-5]|655[0-2][0-9]\\d|65[0-4](\\d){2}|6[0-4](\\d){3}|[1-5](\\d){4}|[1-9](\\d){0,3}))*$"
+        },
+        "service-cluster-ip-range": {
+          "default": "10.10.10.0/24",
+          "description": "Kubernetes DNS service portal IP address, should fall in service-cluster-ip-range network range.",
+          "type": "string",
+          "pattern": "^(?:(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}(?:[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(?:\\/(?:[0-9]|[1-2][0-9]|3[0-2]))$"
+        },
+        "scheduler-service-ip": {
+          "default": "10.10.10.9",
+          "description": "Kubernetes-Mesos scheduler service portal IP address, should fall in service-cluster-ip-range network range.",
+          "type": "string",
+          "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+        },
+        "enable-etcd-server": {
+          "default": true,
+          "description": "Set to false to disable the pre-packaged etcd server component. Do this if you already have an etcd cluster set up that you want to use as the backing store for Kubernetes. Also see the docs for etcd-server-list.",
+          "type": "boolean"
+        },
+        "etcd-server-list": {
+          "description": "Comma-delimited list of URLs that reference etcd-server endpoints. For example, http://myserver:2001,http://anotherserver:2001. Specify this option if you have disabled the built-in etcd-server via disable-etcd-server.",
+          "type": "string"
+        },
+        "cpus": {
+          "default": 1.0,
+          "description": "CPU shares to allocate to each instance.",
+          "minimum": 0.0,
+          "type": "number"
+        },
+        "failover-timeout": {
+          "default": 120,
+          "description": "The failover_timeout for Mesos in seconds. If a new Kubernetes scheduler instance has not re-registered with Mesos this long after a failover, Mesos will shut down all running pods. Requires checkpointing to be enabled.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "apiserver-port": {
+          "default": 25500,
+          "description": "Read/write host port that the Kubernetes apiserver listens on.",
+          "minimum": 1,
+          "maximum": 65535,
+          "type": "integer"
+        },
+        "apiserver-secure-port": {
+          "default": 25502,
+          "description": "The Kubernetes apiserver port from which to serve HTTPS with authentication and authorization.",
+          "minimum": 1,
+          "maximum": 65535,
+          "type": "integer"
+        },
+        "scheduler-driver-port": {
+          "default": 25501,
+          "description": "Host port that the Kubernetes-Mesos scheduler driver listens on.",
+          "minimum": 1,
+          "maximum": 65535,
+          "type": "integer"
+        },
+        "scheduler-port": {
+          "default": 25504,
+          "description": "Host port that the Kubernetes scheduler listens on.",
+          "minimum": 1,
+          "maximum": 65535,
+          "type": "integer"
+        },
+        "controller-manager-port": {
+          "default": 25505,
+          "description": "Host port that the Kubernetes controller-manager listens on.",
+          "minimum": 1,
+          "maximum": 65535,
+          "type": "integer"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of Kubernetes scheduler instances to run.",
+          "minimum": 0,
+          "maximum": 1,
+          "type": "integer"
+        },
+        "logging-verbosity": {
+          "default": 1,
+          "description": "Increase this value to obtain more detailed log messages.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "mem": {
+          "default": 768.0,
+          "description": "Memory (MB) to allocate to each Kubernetes scheduler instance.",
+          "minimum": 128.0,
+          "type": "number"
+        },
+        "default-container-cpu-limit": {
+          "default": 0.25,
+          "description": "CPU shared to allocate to a containter in a pod which is not CPU limited.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "default-container-mem-limit": {
+          "default": 64.0,
+          "description": "Memory (MB) to allocate to a containter in a pod which is not memory limited.",
+          "minimum": 32.0,
+          "type": "number"
+        },
+        "initial-executor-cpus": {
+          "default": 0.25,
+          "description": "Initial CPU shares allocated for the executor container.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "initial-executor-mem": {
+          "default": 128.0,
+          "description": "Initial memory (MB) allocated for the executor container.",
+          "minimum": 128.0,
+          "type": "number"
+        },
+        "mesos-role": {
+          "description": "Mesos role for this framework.",
+          "type": "string"
+        },
+        "uris": {
+          "default": [],
+          "description": "List of URIs that will be download and made available in the current working directory of the scheduler.",
+          "items": {
+            "pattern": "^[\\s]+",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "debug": {
+          "default": false,
+          "description": "Enable debug output",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "framework-name",
+        "cpus",
+        "dns-suffix",
+        "instances",
+        "failover-timeout",
+        "logging-verbosity",
+        "mem",
+        "uris"
+      ],
+      "type": "object"
+    },
+    "mesos": {
+      "depscription": "Mesos specific configuration properties",
+      "properties": {
+        "master": {
+          "default": "zk://master.mesos:2181/mesos",
+          "description": "The URL of the Mesos master. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/mesos. If using ZooKeeper, pay particular attention to the leading zk:// and trailing /mesos! If not using ZooKeeper, standard host:port patterns, like localhost:5050 or 10.0.0.5:5050,10.0.0.6:5050, are also acceptable.",
+          "type": "string"
+        }
+      },
+      "required": ["master"],
+      "type": "object"
+    }
+  },
+  "required": [
+    "kubernetes",
+    "mesos"
+  ],
+  "type": "object"
+}

--- a/repo/packages/K/kubernetes/2/marathon.json
+++ b/repo/packages/K/kubernetes/2/marathon.json
@@ -1,0 +1,95 @@
+{
+  "id": "{{kubernetes.framework-name}}",
+  "cpus": {{kubernetes.cpus}},
+  "mem": {{kubernetes.mem}},
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{kubernetes.docker-image}}",
+      "forcePullImage": true,
+      "network": "HOST"
+    }
+  },
+  "env":{
+    "DEBUG": "{{kubernetes.debug}}",
+    "GLOG_v": "{{kubernetes.logging-verbosity}}",
+    "DEFAULT_DNS_NAME": "{{kubernetes.framework-name}}{{kubernetes.dns-suffix}}",
+    "FRAMEWORK_NAME": "{{kubernetes.framework-name}}",
+    "FRAMEWORK_WEBURI": "http://{{kubernetes.framework-name}}{{kubernetes.dns-suffix}}:{{kubernetes.apiserver-port}}",
+
+    {{#mesos.master}}
+    "K8SM_MESOS_MASTER": "{{mesos.master}}",
+    {{/mesos.master}}
+
+    {{#kubernetes.mesos-role}}
+    "K8SM_MESOS_ROLE": "{{kubernetes.mesos-role}}",
+    {{/kubernetes.mesos-role}}
+
+    {{#kubernetes.enable-etcd-server}}
+    "ENABLE_ETCD_SERVER": "{{kubernetes.enable-etcd-server}}",
+    {{/kubernetes.enable-etcd-server}}
+
+    {{#kubernetes.etcd-server-list}}
+    "ETCD_SERVER_LIST": "{{kubernetes.etcd-server-list}}",
+    {{/kubernetes.etcd-server-list}}
+
+    {{#kubernetes.enable-dns}}
+    "ENABLE_DNS": "{{kubernetes.enable-dns}}",
+    {{/kubernetes.enable-dns}}
+
+    {{#kubernetes.kube-dns-domain}}
+    "DNS_DOMAIN": "{{kubernetes.kube-dns-domain}}",
+    {{/kubernetes.kube-dns-domain}}
+
+    {{#kubernetes.kube-dns-service-ip}}
+    "DNS_SERVER_IP": "{{kubernetes.kube-dns-service-ip}}",
+    {{/kubernetes.kube-dns-service-ip}}
+
+    {{#kubernetes.kube-dns-replicas}}
+    "DNS_REPLICAS": "{{kubernetes.kube-dns-replicas}}",
+    {{/kubernetes.kube-dns-replicas}}
+
+    {{#kubernetes.kube-dns-nameservers}}
+    "DNS_NAMESERVERS": "{{kubernetes.kube-dns-nameservers}}",
+    {{/kubernetes.kube-dns-nameservers}}
+
+    {{#kubernetes.service-cluster-ip-range}}
+    "SERVICE_CLUSTER_IP_RANGE": "{{kubernetes.service-cluster-ip-range}}",
+    {{/kubernetes.service-cluster-ip-range}}
+
+    {{#kubernetes.scheduler-service-ip}}
+    "SCHEDULER_SERVICE_ADDRESS": "{{kubernetes.scheduler-service-ip}}",
+    {{/kubernetes.scheduler-service-ip}}
+
+    "K8SM_FAILOVER_TIMEOUT": "{{kubernetes.failover-timeout}}",
+    "APISERVER_PORT": "{{kubernetes.apiserver-port}}",
+    "APISERVER_SECURE_PORT": "{{kubernetes.apiserver-secure-port}}",
+    "SCHEDULER_PORT": "{{kubernetes.scheduler-port}}",
+    "SCHEDULER_DRIVER_PORT": "{{kubernetes.scheduler-driver-port}}",
+    "SCHEDULER_CONTAIN_POD_RESOURCES": "false",
+    "SCHEDULER_ACCOUNT_FOR_POD_RESOURCES": "false",
+    "CONTROLLER_MANAGER_PORT": "{{kubernetes.controller-manager-port}}",
+    "DEFAULT_CONTAINER_CPU_LIMIT": "{{kubernetes.default-container-cpu-limit}}",
+    "DEFAULT_CONTAINER_MEM_LIMIT": "{{kubernetes.default-container-mem-limit}}",
+    "SCHEDULER_MESOS_EXECUTOR_CPUS": "{{kubernetes.initial-executor-cpus}}",
+    "SCHEDULER_MESOS_EXECUTOR_MEM": "{{kubernetes.initial-executor-mem}}"
+  },
+  "ports": [{{kubernetes.apiserver-port}}, {{kubernetes.apiserver-secure-port}}, {{kubernetes.scheduler-port}}, {{kubernetes.controller-manager-port}}, {{kubernetes.scheduler-driver-port}}],
+  "requirePorts": true,
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "instances": {{kubernetes.instances}},
+  "uris": {{kubernetes.uris}},
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/healthz",
+      "portIndex": 0,
+      "gracePeriodSeconds": 120,
+      "intervalSeconds": 60,
+      "maxConsecutiveFailures": 2
+    }
+  ]
+}

--- a/repo/packages/K/kubernetes/2/marathon.json
+++ b/repo/packages/K/kubernetes/2/marathon.json
@@ -27,13 +27,9 @@
     "K8SM_MESOS_ROLE": "{{kubernetes.mesos-role}}",
     {{/kubernetes.mesos-role}}
 
-    {{#kubernetes.enable-etcd-server}}
-    "ENABLE_ETCD_SERVER": "{{kubernetes.enable-etcd-server}}",
-    {{/kubernetes.enable-etcd-server}}
-
-    {{#kubernetes.etcd-server-list}}
-    "ETCD_SERVER_LIST": "{{kubernetes.etcd-server-list}}",
-    {{/kubernetes.etcd-server-list}}
+    {{#kubernetes.etcd-mesos-framework-name}}
+    "ETCD_MESOS_FRAMEWORK_NAME": "{{kubernetes.etcd-mesos-framework-name}}",
+    {{/kubernetes.etcd-mesos-framework-name}}
 
     {{#kubernetes.enable-dns}}
     "ENABLE_DNS": "{{kubernetes.enable-dns}}",

--- a/repo/packages/K/kubernetes/2/marathon.json
+++ b/repo/packages/K/kubernetes/2/marathon.json
@@ -2,6 +2,8 @@
   "id": "{{kubernetes.framework-name}}",
   "cpus": {{kubernetes.cpus}},
   "mem": {{kubernetes.mem}},
+  "acceptedResourceRoles": {{{marathon.resource-roles}}},
+  "labels": {{{marathon.labels}}},
   "container": {
     "type": "DOCKER",
     "docker": {

--- a/repo/packages/K/kubernetes/2/package.json
+++ b/repo/packages/K/kubernetes/2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kubernetes",
-  "version": "v1.0.6-v0.6.5-alpha",
+  "version": "v1.0.6-v0.6.6-alpha",
   "scm": "https://github.com/mesosphere/kubernetes-mesos",
   "maintainer": "support@mesosphere.io",
   "description": "Kubernetes is an open source system for managing containerized applications across multiple hosts, providing basic mechanisms for deployment, maintenance, and scaling of applications.",

--- a/repo/packages/K/kubernetes/2/package.json
+++ b/repo/packages/K/kubernetes/2/package.json
@@ -3,7 +3,7 @@
   "version": "v1.0.6-v0.6.5-alpha",
   "scm": "https://github.com/mesosphere/kubernetes-mesos",
   "maintainer": "support@mesosphere.io",
-  "description": "Manage a cluster of Linux containers as a single system to accelerate Dev and simplify Ops.",
+  "description": "Kubernetes is an open source system for managing containerized applications across multiple hosts, providing basic mechanisms for deployment, maintenance, and scaling of applications.",
   "framework": true,
   "images": {
     "icon-small": "https://downloads.mesosphere.io/kubernetes/artifacts/images/k8s-48x48.png",

--- a/repo/packages/K/kubernetes/2/package.json
+++ b/repo/packages/K/kubernetes/2/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "kubernetes",
+  "version": "v1.0.6-v0.6.5-alpha",
+  "scm": "https://github.com/mesosphere/kubernetes-mesos",
+  "maintainer": "support@mesosphere.io",
+  "description": "Manage a cluster of Linux containers as a single system to accelerate Dev and simplify Ops.",
+  "framework": true,
+  "images": {
+    "icon-small": "https://downloads.mesosphere.io/kubernetes/artifacts/images/k8s-48x48.png",
+    "icon-medium": "https://downloads.mesosphere.io/kubernetes/artifacts/images/k8s-96x96.png",
+    "icon-large": "https://downloads.mesosphere.io/kubernetes/artifacts/images/k8s-256x256.png"
+  },
+  "tags": ["mesosphere", "framework", "pod", "label", "paas"],
+  "preInstallNotes": "In order for Kubernetes to start successfully all resources must be available in the cluster including ports, CPU shares and RAM.\nWe recommend a minimum of 1 node with 1 CPU share and 1 GB of RAM available for use by the Kubernetes service.\nNote that the service is alpha and there may be bugs, including possible data loss, incomplete features, incorrect documentation or other discrepancies.",
+  "postInstallNotes": "Kubernetes DCOS Service has been successfully installed!\n\n\tDocumentation: https://github.com/mesosphere/kubernetes-mesos\n\tIssues: https://github.com/mesosphere/kubernetes-mesos/issues\n\tWeb UI: <hostname>/service/kubernetes/api/v1/proxy/namespaces/kube-system/services/kube-ui/",
+  "postUninstallNotes": "The Kubernetes DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at http://docs.mesosphere.com/services/kubernetes/#uninstall to clean up any persisted state.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/mesosphere/kubernetes-mesos/blob/master/LICENSE"
+    }
+  ]
+}


### PR DESCRIPTION
Ignore the version in the branch name, the PR title is correct.
- bump docker image version for CM.3 compat: latest k8s/dcos image
- support custom Marathon resource-roles and labels
  - custom `resource-roles`: allows scheduling on public slave
  - custom `labels`: allows admin to tag things like `VIRTUAL_HOST` .. /cc @timfallmk 
- initial support for etcd-mesos
  - runs built-in etcd-server by default (for compat w/ current dcos/stable release); no HA here!
  - set option `kubernetes.etcd-mesos-framework-name` for HA etcd-mesos support (requires CM.3+); this allows the k8s/dcos scheduler container to fail over w/o state loss

To test w/ etcd-mesos integration on CM.3 (currently in EA on CCM):

``` sh
$ dcos config prepend package.sources \
  https://github.com/mesosphere/multiverse/archive/k8sm-v1.0.6-v0.6.5.zip
$ dcos package update --validate
$ dcos package install etcd
$ cat >/tmp/options.json <<EOF
{"kubernetes": { "etcd-mesos-framework-name": "etcd" } }
EOF
$ dcos package install --options=/tmp/options.json kubernetes
```

To test w/o etcd-mesos integration (runs etcd-server inside scheduler container, bad for failover):

``` sh
$ dcos config prepend package.sources \
  https://github.com/mesosphere/multiverse/archive/k8sm-v1.0.6-v0.6.5.zip
$ dcos package update --validate
$ dcos package install kubernetes
```

/cc @karlkfi @sttts @spacejam 
- supercedes #13 
- includes changes from #22 

xref
- docs changes: https://github.com/mesosphere/mesosphere-docs/pull/201
  - http://docs-staging.mesosphere.com.s3-website-us-west-2.amazonaws.com/services/kubernetes/

TODO:
- [x] docker image should include https://github.com/kubernetes/kubernetes/pull/15735 once it lands
