### PR TITLE
Add OpenVPN

### DIFF
--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -133,6 +133,32 @@
       }
     },
     {
+      "currentVersion":"0.0.0-0.1",
+      "description":"Your private path to access network resources and services securely: Server service",
+      "framework":false,
+      "name":"openvpn",
+      "tags":[
+        "vpn",
+        "remote-access"
+      ],
+      "versions":{
+        "0.0.0-0.1":"0"
+      }
+    },
+    {
+      "currentVersion":"0.0.0-0.1",
+      "description":"Your private path to access network resources and services securely: Admin service.",
+      "framework":false,
+      "name":"openvpn-admin",
+      "tags":[
+        "vpn",
+        "remote-access"
+      ],
+      "versions":{
+        "0.0.0-0.1":"0"
+      }
+    },
+    {
       "currentVersion":"0.0.1",
       "description":"Spark Notebook package for DCOS",
       "framework":true,

--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -118,21 +118,6 @@
       }
     },
     {
-      "currentVersion":"0.1.1",
-      "description":"A distributed NoSQL key-value data store that offers high availability, fault tolerance, operational simplicity, and scalability.",
-      "framework":true,
-      "name":"riak",
-      "tags":[
-        "mesosphere",
-        "framework",
-        "database",
-        "riak"
-      ],
-      "versions":{
-        "0.1.1":"0"
-      }
-    },
-    {
       "currentVersion":"0.0.0-0.1",
       "description":"Your private path to access network resources and services securely: Server service",
       "framework":false,
@@ -156,6 +141,21 @@
       ],
       "versions":{
         "0.0.0-0.1":"0"
+      }
+    },
+    {
+      "currentVersion":"0.1.1",
+      "description":"A distributed NoSQL key-value data store that offers high availability, fault tolerance, operational simplicity, and scalability.",
+      "framework":true,
+      "name":"riak",
+      "tags":[
+        "mesosphere",
+        "framework",
+        "database",
+        "riak"
+      ],
+      "versions":{
+        "0.1.1":"0"
       }
     },
     {

--- a/repo/packages/O/openvpn-admin/0/config.json
+++ b/repo/packages/O/openvpn-admin/0/config.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "openvpn-admin": {
+      "type": "object",
+      "properties": {
+        "framework-name": {
+            "default": "openvpn-admin",
+            "description": "openvpn framework name",
+            "type": "string"
+        },
+        "cpus": {
+            "default": 0.01,
+            "description": "CPU shares to allocate to each openvpn instance.",
+            "minimum": 0.01,
+            "type": "number"
+        },
+        "mem": {
+            "default": 128.0,
+            "description": "Memory (MB) to allocate to each openvpn task.",
+            "minimum": 64.0,
+            "type": "number"
+        },
+        "instances": {
+            "default": 1,
+            "description": "Number of openvpn instances to run.",
+            "minimum": 1,
+            "type": "integer"
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/repo/packages/O/openvpn-admin/0/marathon.json
+++ b/repo/packages/O/openvpn-admin/0/marathon.json
@@ -1,0 +1,32 @@
+{
+  "id": "{{openvpn-admin.framework-name}}",
+  "cpus": {{openvpn-admin.cpus}},
+  "mem": {{openvpn-admin.mem}},
+  "instances": {{openvpn-admin.instances}},
+  "args": [ "admin" ],
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "mesosphere/dcos-openvpn",
+      "forcePullImage": true,
+      "network": "BRIDGE",
+      "portMappings": [{ "containerPort": 5000, "protocol": "tcp" }]
+    }
+  },
+  "healthChecks": [
+    {
+      "gracePeriodSeconds": 120,
+      "intervalSeconds": 30,
+      "maxConsecutiveFailures": 0,
+      "path": "/status",
+      "portIndex": 0,
+      "protocol": "HTTP",
+      "timeoutSeconds": 5
+    }
+  ],
+  "ports": [],
+  "env": {
+    "MESOS_CONFIG": "zk://master.mesos:2181/mesos",
+    "FRAMEWORK_NAME": "{{openvpn-admin.framework-name}}"
+  }
+}

--- a/repo/packages/O/openvpn-admin/0/package.json
+++ b/repo/packages/O/openvpn-admin/0/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "openvpn-admin",
+  "version": "0.0.0-0.1",
+  "scm": "https://github.com/mesosphere/dcos-openvpn",
+  "description": "Your private path to access network resources and services securely: Admin service.",
+  "maintainer": "support@mesosphere.io",
+  "images": {
+    "icon-small": "https://downloads.mesosphere.io/openvpn/artifacts/images/openvpn-48x48.png",
+    "icon-medium": "https://downloads.mesosphere.io/openvpn/artifacts/images/openvpn-96x96.png",
+    "icon-large": "https://downloads.mesosphere.io/openvpn/artifacts/images/openvpn-256x256.png"
+  },
+  "tags": ["vpn", "remote-access"],
+  "preInstallNotes": "We recommend a minimum of 0.01 CPUs and 64 MB of RAM available for the Marathon Service.",
+  "postInstallNotes": "OpenVPN DCOS Service has been successfully installed!\nSee https://github.com/mesosphere/dcos-openvpn on how to create users.",
+  "postUninstallNotes": "OpenVPN DCOS Service has been uninstalled and will no longer run.\nSee https://github.com/mesosphere/dcos-openvpn on how to remove persisted state.",
+  "licenses": [
+    {
+      "name": "GNU General Public License version 2",
+      "url": "https://github.com/OpenVPN/openvpn/blob/master/COPYING"
+    },
+    {
+      "name": "The MIT License (MIT)",
+      "url": "https://github.com/kylemanna/docker-openvpn/blob/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/O/openvpn/0/config.json
+++ b/repo/packages/O/openvpn/0/config.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "openvpn": {
+      "type": "object",
+      "properties": {
+        "framework-name": {
+            "default": "openvpn",
+            "description": "openvpn framework name",
+            "type": "string"
+        },
+        "cpus": {
+            "default": 0.01,
+            "description": "CPU shares to allocate to each openvpn instance.",
+            "minimum": 0.01,
+            "type": "number"
+        },
+        "mem": {
+            "default": 128.0,
+            "description": "Memory (MB) to allocate to each openvpn task.",
+            "minimum": 64.0,
+            "type": "number"
+        },
+        "instances": {
+            "default": 1,
+            "description": "Number of openvpn instances to run.",
+            "minimum": 1,
+            "type": "integer"
+        },
+        "port": {
+            "default": 1194,
+            "description": "UDP port to bind to.",
+            "minimum": 1,
+            "type": "integer"
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/repo/packages/O/openvpn/0/marathon.json
+++ b/repo/packages/O/openvpn/0/marathon.json
@@ -1,0 +1,27 @@
+{
+  "id": "{{openvpn.framework-name}}",
+  "cpus": {{openvpn.cpus}},
+  "mem": {{openvpn.mem}},
+  "instances": {{openvpn.instances}},
+  "args": [ "server" ],
+  "acceptedResourceRoles": ["slave_public"],
+  "constraints": [
+    ["hostname", "UNIQUE"]
+  ],
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "mesosphere/dcos-openvpn",
+      "forcePullImage": true,
+      "network": "BRIDGE",
+      "privileged": true,
+      "portMappings": [
+        { "hostPort": {{openvpn.port}}, "containerPort": 1194, "protocol": "udp" }
+      ]
+    }
+  },
+  "env": {
+    "MESOS_CONFIG": "zk://master.mesos:2181/mesos",
+    "FRAMEWORK_NAME": "{{openvpn.framework-name}}"
+  }
+}

--- a/repo/packages/O/openvpn/0/package.json
+++ b/repo/packages/O/openvpn/0/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "openvpn",
+  "version": "0.0.0-0.1",
+  "scm": "https://github.com/mesosphere/dcos-openvpn",
+  "description": "Your private path to access network resources and services securely: Server service",
+  "maintainer": "support@mesosphere.io",
+  "images": {
+    "icon-small": "https://downloads.mesosphere.io/openvpn/artifacts/images/openvpn-48x48.png",
+    "icon-medium": "https://downloads.mesosphere.io/openvpn/artifacts/images/openvpn-96x96.png",
+    "icon-large": "https://downloads.mesosphere.io/openvpn/artifacts/images/openvpn-256x256.png"
+  },
+  "tags": ["vpn", "remote-access"],
+  "preInstallNotes": "We recommend a minimum of 0.01 CPUs and 64 MB of RAM available for the Marathon Service.",
+  "postInstallNotes": "OpenVPN DCOS Service has been successfully installed!\nSee https://github.com/mesosphere/dcos-openvpn on how to create users.",
+  "postUninstallNotes": "OpenVPN DCOS Service has been uninstalled and will no longer run.\nSee https://github.com/mesosphere/dcos-openvpn on how to remove persisted state.",
+  "licenses": [
+    {
+      "name": "GNU General Public License version 2",
+      "url": "https://github.com/OpenVPN/openvpn/blob/master/COPYING"
+    },
+    {
+      "name": "The MIT License (MIT)",
+      "url": "https://github.com/kylemanna/docker-openvpn/blob/master/LICENSE"
+    }
+  ]
+}


### PR DESCRIPTION
Okay, this is the new version my PR to add openvpn. It now uses two different apps so we can schedule it with marathon instead of reinventing the wheel by using our own scheduler.
It's split into two services so that while the server runs on the public slaves, the admin api runs on a private slave and can't be reached from the public internet.
