### PR TITLE
marathon-lb: Fix port allocation

### DIFF
--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -88,16 +88,19 @@
       }
     },
     {
-      "currentVersion":"1.596.2",
-      "description":"Jenkins is an award-winning application that monitors executions of repeated jobs, such as building a software project or jobs run by cron.",
+      "currentVersion":"0.1.0",
+      "description":"Jenkins is an award-winning, cross-platform, continuous integration and continuous delivery application that increases your productivity. Use Jenkins to build and test your software projects continuously making it easier for developers to integrate changes to the project, and making it easier for users to obtain a fresh build. It also allows you to continuously deliver your software by providing powerful ways to define your build pipelines and integrating with a large number of testing and deployment technologies.",
       "framework":true,
       "name":"jenkins",
       "tags":[
+        "mesosphere",
         "framework",
-        "continuous-integration"
+        "continuous-integration",
+        "ci",
+        "jenkins"
       ],
       "versions":{
-        "1.596.2":"0"
+        "0.1.0":"0"
       }
     },
     {

--- a/repo/packages/M/marathon-lb/0/marathon.json
+++ b/repo/packages/M/marathon-lb/0/marathon.json
@@ -31,6 +31,7 @@
     }
   ],
   "ports": [ 80, 443 ],
+  "requirePorts": true,
   "env": {
     "FRAMEWORK_NAME": "{{marathon-lb.framework-name}}",
     "HAPROXY_SSL_CERT": "{{marathon-lb.ssl-cert}}"


### PR DESCRIPTION
requirePorts is required to set if we need to allocate the specified ports.

(This also fixes the jenkins metadata, looks like changing that slipped through somehow)
