### PR TITLE
Marathon-lb fixes.

### DIFF
--- a/repo/packages/M/marathon-lb/0/config.json
+++ b/repo/packages/M/marathon-lb/0/config.json
@@ -23,7 +23,7 @@
           "type": "number"
         },
         "instances": {
-          "default": 2,
+          "default": 1,
           "description": "Number of instances to run.",
           "minimum": 1,
           "type": "integer"
@@ -33,7 +33,7 @@
           "type": "string"
         },
         "role": {
-          "default": "slave",
+          "default": null,
           "description": "Deploy marathon-lb only on nodes with this role.",
           "type": "string"
         }

--- a/repo/packages/M/marathon-lb/0/marathon.json
+++ b/repo/packages/M/marathon-lb/0/marathon.json
@@ -31,6 +31,7 @@
     }
   ],
   "ports": [ 80, 443 ],
+  "requirePorts":true,
   "env": {
     "FRAMEWORK_NAME": "{{marathon-lb.framework-name}}",
     "HAPROXY_SSL_CERT": "{{marathon-lb.ssl-cert}}"


### PR DESCRIPTION
- make sure 'requirePorts' is true
- `slave` is not a valid role
- use just 1 instance by default

cc @discordianfish
