### PR TITLE
HAProxy's Health Check portIndex in Marathon must be 2

### DIFF
--- a/repo/packages/M/marathon-lb/0/marathon.json
+++ b/repo/packages/M/marathon-lb/0/marathon.json
@@ -24,7 +24,7 @@
     {
       "path": "/_haproxy_health_check",
   {{#marathon-lb.bind-http-https}}
-      "portIndex": 3,
+      "portIndex": 2,
   {{/marathon-lb.bind-http-https}}
   {{^marathon-lb.bind-http-https}}
       "portIndex": 0,


### PR DESCRIPTION
The healthcheck for HAProxy's monitor-uri /_haproxy_health_check listens on port 9090 whose portIndex in marathon corresponds to 2, not 3 - a classic off by one error
