### PR TITLE
Update Jenkins package

### DIFF
--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -88,7 +88,7 @@
       }
     },
     {
-      "currentVersion":"0.1.1",
+      "currentVersion":"0.1.2",
       "description":"Jenkins is an award-winning, cross-platform, continuous integration and continuous delivery application that increases your productivity. Use Jenkins to build and test your software projects continuously making it easier for developers to integrate changes to the project, and making it easier for users to obtain a fresh build. It also allows you to continuously deliver your software by providing powerful ways to define your build pipelines and integrating with a large number of testing and deployment technologies.",
       "framework":true,
       "name":"jenkins",
@@ -101,7 +101,8 @@
       ],
       "versions":{
         "0.1.0":"0",
-        "0.1.1":"1"
+        "0.1.1":"1",
+        "0.1.2":"2"
       }
     },
     {

--- a/repo/packages/J/jenkins/2/config.json
+++ b/repo/packages/J/jenkins/2/config.json
@@ -1,0 +1,53 @@
+{
+  "type": "object",
+  "properties": {
+    "jenkins": {
+      "description": "Jenkins framework configuration properties",
+      "type": "object",
+      "properties": {
+        "framework-name": {
+          "description": "The framework name to register with Mesos.",
+          "type": "string",
+          "default": "jenkins"
+        },
+        "host": {
+            "description": "The host that Jenkins agents will use to connect back to the master.",
+            "type": "string",
+            "default": "$HOST"
+        },
+        "cpus": {
+            "description": "CPU shares to allocate to each Jenkins master.",
+            "type": "number",
+            "default": 1.0,
+            "minimum": 0.1
+        },
+        "mem": {
+            "description": "Memory to allocate to each Jenkins master.",
+            "type": "number",
+            "default": 1024.0,
+            "minimum": 1024.0
+        },
+        "host-volume": {
+          "description": "The location of a volume on the host to be used for persisting Jenkins configuration and build data. The final location will be derived from this value plus the name set in `framework-name` (e.g. `/mnt/host_volume/jenkins`). Note that this path must be the same on all DCOS agents.",
+          "type": "string",
+          "default": "/tmp"
+        },
+        "catalina-opts": {
+            "description": "Optional arguments to pass to the Tomcat application server.",
+            "type": "string",
+            "default": "-Xms512m -Xmx512m -Dport.http=$PORT0 -Dcontext.path=$JENKINS_CONTEXT"
+        }
+      },
+      "required": [
+        "framework-name",
+        "host",
+        "cpus",
+        "mem",
+        "host-volume"
+      ]
+    }
+  },
+  "required": [
+    "jenkins"
+  ]
+}

--- a/repo/packages/J/jenkins/2/marathon.json
+++ b/repo/packages/J/jenkins/2/marathon.json
@@ -1,0 +1,42 @@
+{
+  "id": "{{jenkins.framework-name}}",
+  "cpus": {{jenkins.cpus}},
+  "mem": {{jenkins.mem}},
+  "instances": 1,
+  "env": {
+      "CATALINA_OPTS": "{{jenkins.catalina-opts}}",
+      "JENKINS_FRAMEWORK_NAME": "{{jenkins.framework-name}}",
+      "JENKINS_CONTEXT": "/service/{{jenkins.framework-name}}",
+      "LD_LIBRARY_PATH": "/opt/mesosphere/lib"
+  },
+   "container": {
+       "type": "DOCKER",
+       "docker": {
+           "image": "mesosphere/jenkins:0.1.1",
+           "network": "HOST"
+       },
+       "volumes": [
+           {
+               "containerPath": "/var/jenkins_home",
+               "hostPath": "{{jenkins.host-volume}}/{{jenkins.framework-name}}",
+               "mode": "RW"
+           },
+           {
+               "containerPath": "/opt/mesosphere",
+               "hostPath": "/opt/mesosphere",
+               "mode": "RO"
+           }
+       ]
+   },
+   "healthChecks": [
+    {
+      "path": "/service/{{jenkins.framework-name}}",
+      "portIndex": 0,
+      "protocol": "HTTP",
+      "gracePeriodSeconds": 30,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3
+    }
+  ]
+}

--- a/repo/packages/J/jenkins/2/marathon.json
+++ b/repo/packages/J/jenkins/2/marathon.json
@@ -12,7 +12,7 @@
    "container": {
        "type": "DOCKER",
        "docker": {
-           "image": "mesosphere/jenkins:0.1.1",
+           "image": "mesosphere/jenkins:0.1.2",
            "network": "HOST"
        },
        "volumes": [

--- a/repo/packages/J/jenkins/2/package.json
+++ b/repo/packages/J/jenkins/2/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "jenkins",
+  "version": "0.1.1",
+  "scm": "https://github.com/mesosphere/jenkins-mesos.git",
+  "maintainer": "support@mesosphere.io",
+  "website": "https://jenkins-ci.org",
+  "framework": true,
+  "description": "Jenkins is an award-winning, cross-platform, continuous integration and continuous delivery application that increases your productivity. Use Jenkins to build and test your software projects continuously making it easier for developers to integrate changes to the project, and making it easier for users to obtain a fresh build. It also allows you to continuously deliver your software by providing powerful ways to define your build pipelines and integrating with a large number of testing and deployment technologies.",
+  "tags": ["mesosphere", "framework", "continuous-integration", "ci", "jenkins"],
+  "preInstallNotes": "WARNING: Jenkins on DCOS is currently in ALPHA. There may be bugs, incomplete\nfeatures, incorrect documentation, or other discrepancies.\n\nIf you didn't provide a value for `host-volume` in the CLI,\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n",
+  "postInstallNotes": "Jenkins has been installed.",
+  "postUninstallNotes": "Jenkins has been uninstalled. Note that any data persisted to a NFS share still exists and will need to be manually removed.",
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/jenkins/assets/icon-service-jenkins-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/jenkins/assets/icon-service-jenkins-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/jenkins/assets/icon-service-jenkins-large.png"
+  },
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/mesosphere/jenkins-mesos/blob/master/LICENSE"
+    }
+  ]
+}
+

--- a/repo/packages/J/jenkins/2/package.json
+++ b/repo/packages/J/jenkins/2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jenkins",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "scm": "https://github.com/mesosphere/jenkins-mesos.git",
   "maintainer": "support@mesosphere.io",
   "website": "https://jenkins-ci.org",


### PR DESCRIPTION
Update default memory for Jenkins task to 1024mb. Prevents task flapping due to task getting killed by Mesos.

Updates version of Docker image to 0.1.2.
