### PR TITLE
Bump kubernetes subcommand verison to v0.2.0

### DIFF
--- a/repo/packages/K/kubernetes/3/command.json
+++ b/repo/packages/K/kubernetes/3/command.json
@@ -1,6 +1,6 @@
 {
   "pip": [
     "dcos<1.0",
-    "git+https://github.com/mesosphere/dcos-kubernetes.git#dcos-kubectl=v0.1.3"
+    "git+https://github.com/mesosphere/dcos-kubernetes.git#dcos-kubectl=v0.2.0"
   ]
 }


### PR DESCRIPTION
Version v0.2.0 of https://github.com/mesosphere/dcos-kubectl finally runs fine with Python 3.x.
