### PR TITLE
zeppelin 0.5.6

### DIFF
--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -231,7 +231,7 @@
       }
     },
     {
-      "currentVersion":"0.0.1",
+      "currentVersion":"0.5.6",
       "description":"Zeppelin is a web-based notebook that enables interactive data analytics",
       "framework":true,
       "name":"zeppelin",
@@ -244,7 +244,8 @@
         "interactive"
       ],
       "versions":{
-        "0.0.1":"0"
+        "0.0.1":"0",
+        "0.5.6":"1"
       }
     }
   ],

--- a/repo/packages/Z/zeppelin/1/config.json
+++ b/repo/packages/Z/zeppelin/1/config.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "zeppelin": {
+            "type": "object",
+            "properties": {
+                "spark_uri":  {
+                    "description": "The URI of the Spark distribution to run with Zeppelin.",
+                    "type": "string",
+                    "default": "https://downloads.mesosphere.io/spark/assets/spark-1.6.0.tgz"
+                },
+                "spark_version":  {
+                    "description": "The version of the Spark distribution to run with Zeppelin.",
+                    "type": "string",
+                    "default": "spark-1.6.0"
+                },
+                "spark_docker_image":  {
+                    "description": "The URI of the Spark docker image to use in spark.mesos.executor.docker.image",
+                    "type": "string",
+                    "default": "mesosphere/spark:1.6.0"
+                }
+            },
+            "required": [
+                "spark_uri",
+                "spark_version",
+                "spark_docker_image"
+            ]
+        }
+    }
+}

--- a/repo/packages/Z/zeppelin/1/marathon.json
+++ b/repo/packages/Z/zeppelin/1/marathon.json
@@ -1,0 +1,24 @@
+{
+    "id": "/zeppelin",
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "mesosphere/zeppelin:0.5.6",
+            "network": "HOST"
+        }
+    },
+    "healthChecks": [{
+        "protocol": "TCP",
+        "gracePeriodSeconds": 300,
+        "intervalSeconds": 60,
+        "portIndex": 0,
+        "timeoutSeconds": 15,
+        "maxConsecutiveFailures": 3
+    }],
+    "cmd": "sed \"s#<value>8080</value>#<value>$PORT0</value>#\" < conf/zeppelin-site.xml.template > conf/zeppelin-site.xml && sed -i \"s#<value>-1</value>#<value>$PORT1</value>#\" conf/zeppelin-site.xml && SPARK_HOME=${MESOS_SANDBOX}/{{zeppelin.spark_version}} SPARK_MESOS_EXECUTOR_DOCKER_IMAGE={{zeppelin.spark_docker_image}} bin/zeppelin.sh start",
+    "ports": [0, 0],
+    "cpus": 1,
+    "mem": 2048.0,
+    "uris": ["{{zeppelin.spark_uri}}"],
+    "acceptedResourceRoles": ["slave_public"]
+}

--- a/repo/packages/Z/zeppelin/1/package.json
+++ b/repo/packages/Z/zeppelin/1/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "zeppelin",
+  "version": "0.5.6",
+  "scm": "https://github.com/apache/incubator-zeppelin",
+  "maintainer": "support@mesosphere.io",
+  "description": "Zeppelin is a web-based notebook that enables interactive data analytics",
+  "framework": true,
+  "tags": ["nflabs", "framework", "bigdata", "spark", "notebook", "interactive"],
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/zeppelin/assets/icon-service-zeppelin-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/zeppelin/assets/icon-service-zeppelin-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/zeppelin/assets/icon-service-zeppelin-large.png"
+  },
+  "postInstallNotes": "Zeppelin has been successfully installed!\nNote that the service is experimental and there may be bugs, incomplete features, incorrect documentation or other discrepancies."
+}


### PR DESCRIPTION
I also updated http://github.com/mesosphere/zeppelin-docker

Most changes are to the above repo:
- I updated the mesos base image of the zeppelin docker image to 0.25
- I set zeppelin to a stable version (0.5.5).  It was previously building from master
- I removed the dependencies on fixed docker versions, and instead made them configurable in this package

I've tested this manually

Also, this isn't very useful to our CE users, because it gets launched on a private slave, and we still don't have a good proxy solution.  I don't know about EE users.  My understanding is that most of them can't use the universe/multiverse due to firewall restrictions. cc @keithchambers 
