### PR TITLE
launches Zeppelin on public node

### DIFF
--- a/repo/packages/Z/zeppelin/0/config.json
+++ b/repo/packages/Z/zeppelin/0/config.json
@@ -5,6 +5,11 @@
         "zeppelin": {
             "type": "object",
             "properties": {
+                "role": {
+                     "description": "The accepted resource roles, for example slave_public. By default, this will deploy to any agents with the * role.",
+                     "type": "string",
+                     "default": "*"
+                 },
                 "spark_version":  {
                     "description": "The version of the Spark distribution to run with Zeppelin.",
                     "type": "string",

--- a/repo/packages/Z/zeppelin/0/marathon.json.mustache
+++ b/repo/packages/Z/zeppelin/0/marathon.json.mustache
@@ -1,5 +1,6 @@
 {
     "id": "/zeppelin",
+    "acceptedResourceRoles": [ "slave_public" ],
     "container": {
         "type": "DOCKER",
         "docker": {
@@ -15,10 +16,6 @@
         "timeoutSeconds": 15,
         "maxConsecutiveFailures": 3
     }],
-    "labels": {
-        "HAPROXY_GROUP": "external",
-        "HAPROXY_0_VHOST": "{{zeppelin.vhost}}"
-    },
     "cmd": "sed \"s#<value>8080</value>#<value>$PORT0</value>#\" < conf/zeppelin-site.xml.template > conf/zeppelin-site.xml && sed -i \"s#<value>-1</value>#<value>$PORT1</value>#\" conf/zeppelin-site.xml && SPARK_HOME=${MESOS_SANDBOX}/{{zeppelin.spark_version}} SPARK_MESOS_EXECUTOR_DOCKER_IMAGE={{resource.assets.container.docker.spark-docker}} bin/zeppelin.sh start",
     "ports": [0, 0],
     "cpus": 1,

--- a/repo/packages/Z/zeppelin/0/marathon.json.mustache
+++ b/repo/packages/Z/zeppelin/0/marathon.json.mustache
@@ -1,6 +1,6 @@
 {
     "id": "/zeppelin",
-    "acceptedResourceRoles": [ "slave_public" ],
+    "acceptedResourceRoles": [ "{{zeppelin.role}}" ],
     "container": {
         "type": "DOCKER",
         "docker": {


### PR DESCRIPTION
In order to make the DCOS tutorials simpler, this PR changes the Zeppelin launch from Marathon-lb support to public node. @pyronicide can you pls review and merge?
