### PR TITLE
Bugfix: Explicitely user framework port for health check, too, for Quobyte

### DIFF
--- a/repo/packages/Q/quobyte/0/marathon.json.mustache
+++ b/repo/packages/Q/quobyte/0/marathon.json.mustache
@@ -28,7 +28,7 @@
   "healthChecks": [
     {
       "path": "/v1/health",
-      "portIndex": 0,
+      "port": {{quobyte.port}},
       "protocol": "HTTP",
       "gracePeriodSeconds": 300,
       "intervalSeconds": 60,


### PR DESCRIPTION
This change explicitely sets the frameworks port for health checks, too.
